### PR TITLE
Verifing that sockets are still connected before we check them out of the pool.

### DIFF
--- a/restkit/manager/base.py
+++ b/restkit/manager/base.py
@@ -15,9 +15,6 @@ import time
 
 from ..sock import close
 
-import logging
-log = logging.getLogger(__name__)
-
 class ConnectionReaper(threading.Thread):
     """ connection reaper thread. Open a thread that will murder iddle
     connections after a delay """
@@ -141,19 +138,12 @@ class Manager(object):
     def is_closed(self, sck):
         if sck is None:
             return True
-	log.debug("Testing socket %d for connectedness:", sck.fileno())
-	if True:
-		r, _, _ = select.select([sck], [], [], 0)
-		if not r:
-			return False
-		read = sck.recv(1024)
-		log.debug("Read from socket: %r", read)
-		assert read == '', "Unread data found on socket"
-		if read == '':
-			return True
-		else:
-			sck.close()
-			return True
+	r, _, _ = select.select([sck], [], [], 0)
+	if not r:
+	    return False
+	read = sck.recv(1024)
+	sck.close()
+	return True
 
     def store_socket(self, sck, addr, ssl=False):
         """ store a socket in the pool to reuse it across threads """


### PR DESCRIPTION
Hi there.

I'd found that my application would fail to make a request after about a minute or so of inactivity--after the CouchDB server had timed out the sockets. It looks like the library only notices that the sockets were closed when it tries to use them, and thus ended up spends all of it's retries trying to find a socket from the pool of closed sockets.

In this case, I check if the socket is closed in the manager's is_closed method before returning it. 

Enjoy.
