### PR TITLE
Don't catch KeyboardInterrupt and SystemExit

### DIFF
--- a/restkit/client.py
+++ b/restkit/client.py
@@ -414,8 +414,6 @@ class Client(object):
                         errno.EPIPE, errno.ECONNREFUSED,
                         errno.ECONNRESET, errno.EBADF) or tries <= 0:
                     raise RequestError("socket.error: %s" % str(e))
-            except (KeyboardInterrupt, SystemExit):
-                break
             except (StopIteration, NoMoreData):
                 connection.close()
                 if tries <= 0:
@@ -426,7 +424,7 @@ class Client(object):
                                 not isinstance(request.body, types.StringTypes):
                             raise RequestError("connection closed and can't"
                                     + "be resent")
-            except:
+            except Exception:
                 # unkown error
                 log.debug("unhandled exception %s" %
                         traceback.format_exc())


### PR DESCRIPTION
When these are caught restkit.request() returns "None" rather than the program exiting like expected.

Changing "except:" to "except Exception:" also avoids catching these before re-raising.  Since Python 2.5 exceptions like KeyboardInterrupt and SystemExit that are not normally meant to be caught extend BaseException and not Exception:
http://docs.python.org/library/exceptions.html#exceptions.KeyboardInterrupt
