### PR TITLE
Fix spelling error in ResourceGone exception

### DIFF
--- a/restkit/resource.py
+++ b/restkit/resource.py
@@ -203,7 +203,7 @@ class Resource(object):
                                 http_code=resp.status_int, 
                                 response=resp)
                 elif resp.status_int == 410:
-                    raise ResouceGone(resp.body_string(), response=resp)
+                    raise ResourceGone(resp.body_string(), response=resp)
                 else:
                     raise RequestFailed(resp.body_string(), 
                                 http_code=resp.status_int,


### PR DESCRIPTION
This is a tiny misspelling but the Resource request fails on a 410 as a result. I didn't bother putting it on different branch because it's just one change. 
