### PR TITLE
MultipartForm Hook and Fix

### DIFF
--- a/restkit/wrappers.py
+++ b/restkit/wrappers.py
@@ -89,8 +89,8 @@ class Request(object):
             else:
                 ctype = "application/x-www-form-urlencoded; charset=utf-8"
                 self._body = form_encode(body)
-        elif hasattr(body, "boundary"):
-            ctype = "multipart/form-data; boundary=%s" % self.body.boundary
+        elif hasattr(body, "boundary") and hasattr(body, "get_size"):
+            ctype = "multipart/form-data; boundary=%s" % body.boundary
             clen = body.get_size()
             self._body = body
         else:


### PR DESCRIPTION
1) Added hook for BoundaryItem subclasses to handle unreadable values
2) Added new param in MultipartForm init to use different BoundaryItem class
3) MultipartForm.get_size bug fix
4) Different use of CRLF and --BOUNDARY--
5) Bug Fix in Request._set_body when a MultipartForm is passed as payload
