### PR TITLE
Fix debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://benoitc.github.com/restkit
 Package: python-restkit
 Architecture: all
 Depends: ${python:Depends}, ${shlibs:Depends}, ${misc:Depends},
-python-http-parser(>=0.6.0)
+    python-http-parser(>=0.6.0)
 Provides: ${python:Provides}
 Description: Python REST kit
  An HTTP resource kit for Python


### PR DESCRIPTION
Fix a simple missing tabulation that broke the dpkg-buildpackage -rfakeroot
