### PR TITLE
Encode unicode values as utf-8 when building url in oauth2.Request.to_url. 

### DIFF
--- a/restkit/oauth2.py
+++ b/restkit/oauth2.py
@@ -399,6 +399,8 @@ class Request(dict):
             query = base_url[4]
         query = parse_qs(query)
         for k, v in self.items():
+            if isinstance(v, unicode):
+                v = v.encode("utf-8")
             query.setdefault(k, []).append(v)
         
         try:


### PR DESCRIPTION
This fixes a bug where utf-8 encoded GET parameters are decoded back to unicode during oauth signing and to_url just tries to encode them to ascii after signing, which fails.
