### PR TITLE
Fix OAuth parameter generation in filters.py

### DIFF
--- a/restkit/filters.py
+++ b/restkit/filters.py
@@ -89,11 +89,12 @@ class OAuthFilter(object):
       
         raw_url = urlunparse((parsed_url.scheme, parsed_url.netloc,
                 parsed_url.path, '', '', ''))
-        
+
         oauth_req = Request.from_consumer_and_token(self.consumer, 
                         token=self.token, http_method=request.method, 
-                        http_url=raw_url, parameters=params)
-                    
+                        http_url=raw_url, parameters=params,
+                        is_form_encoded=form)
+
         oauth_req.sign_request(self.method, self.consumer, self.token)
         
         if form:

--- a/tests/009-test-oauth_filter.py
+++ b/tests/009-test-oauth_filter.py
@@ -70,10 +70,15 @@ def test_002(o, u, b):
 
 @oauth_request('two_legged')
 def test_003(o, u, b):
-    r = request(u, "POST", body=b, filters=[o])
+    r = request(u, "POST", body=b, filters=[o],
+                headers={"Content-type": "application/x-www-form-urlencoded"})
     import sys
     print >>sys.stderr, r.body_string()
     t.eq(r.status_int, 200)
+    # Because this is a POST and an application/x-www-form-urlencoded, the OAuth
+    # can include the OAuth parameters directly into the body of the form, however
+    # it MUST NOT include the 'oauth_body_hash' parameter in these circumstances.
+    t.isnotin("oauth_body_hash", r.request.body)
 
 @oauth_request('two_legged')
 def test_004(o, u, b):


### PR DESCRIPTION
- The filter was generating the oauth_body_hash parameter when
  it shouldn't. This patch corrects and tests that condition.
