### PR TITLE
New: Proxy with PEP 333-compliant chunked-response support (based on Paste's Proxy class)

### DIFF
--- a/restkit/contrib/wsgi_proxy.py
+++ b/restkit/contrib/wsgi_proxy.py
@@ -260,7 +260,7 @@ class PasteProxy(object):
         res = conn.request(u'%s://%s%s' % (self.scheme, self.host, path),
                            environ['REQUEST_METHOD'],
                            body=body, headers=headers)
-        headers_out = parse_headers(res.headerslist, stream=self.stream)
+        headers_out = filter_headers(res.headerslist, stream=self.stream)
 
         status = res.status
         start_response(status, headers_out)
@@ -282,9 +282,9 @@ class PasteProxy(object):
         return body
 
 
-def parse_headers(headers_list, stream=False):
+def filter_headers(headers_list, stream=False):
     """
-    Turn a Message object into a list of WSGI-style headers.
+    Filter headers list of WSGI-style headers.
     """
     headers_out = []
     for header, value in headers_list:


### PR DESCRIPTION
I tried to figure out some bug about partial responses using `HostProxy`. It occur on requests that works fine with Paste's [Proxy](http://pythonpaste.org/modules/proxy.html#paste.proxy.Proxy) middleware. Finally, I found the problem to be the HostProxy implementation of chunked responses.

By some PEP 333 [chapter](http://www.python.org/dev/peps/pep-0333/#handling-the-content-length-header), only the server MAY add chunked responses headers, but it usually does so only if Content-Length is not set. At least Gunicorn seems to do chunked very fine, if no Content-Length is set, AFAIK.

So, I copied over `paste.proxy.Proxy` code as a new starting point and adapted to use restkit client and to allow streaming of the client response.

This works very good for me. I added no tests, but its working over my blog http://kombobreaker.com/blog

I dont know where the new class should be: wsgi_proxy.py or a new module?
Waiting for your feedback and/or merge.
