### PR TITLE
Fix timeout parameter in restkit.client.Client. fix #109

### DIFF
--- a/restkit/client.py
+++ b/restkit/client.py
@@ -185,6 +185,7 @@ class Client(object):
         if not conn:
             conn = self._pool.get(host=addr[0], port=addr[1],
                     pool=self._pool, is_ssl=is_ssl,
+                    timeout=self.timeout,
                     extra_headers=extra_headers, **self.ssl_args)
 
 
@@ -215,6 +216,7 @@ class Client(object):
 
                 conn = self._pool.get(host=addr[0], port=addr[1],
                     pool=self._pool, is_ssl=is_ssl,
+                    timeout=self.timeout,
                     extra_headers=[], proxy_pieces=proxy_pieces, **self.ssl_args)
             else:
                 headers = []
@@ -223,6 +225,7 @@ class Client(object):
 
                 conn = self._pool.get(host=addr[0], port=addr[1],
                         pool=self._pool, is_ssl=False,
+                        timeout=self.timeout,
                         extra_headers=[], **self.ssl_args)
             return conn
 

--- a/restkit/conn.py
+++ b/restkit/conn.py
@@ -22,11 +22,14 @@ DNS_TIMEOUT = 60
 class Connection(Connector):
 
     def __init__(self, host, port, backend_mod=None, pool=None,
-            is_ssl=False, extra_headers=[], proxy_pieces=None, **ssl_args):
+            is_ssl=False, extra_headers=[], proxy_pieces=None, timeout=None,
+            **ssl_args):
 
         # connect the socket, if we are using an SSL connection, we wrap
         # the socket.
         self._s = backend_mod.Socket(socket.AF_INET, socket.SOCK_STREAM)
+        if timeout is not None:
+            self._s.settimeout(timeout)
         self._s.connect((host, port))
         if proxy_pieces:
             self._s.sendall(proxy_pieces)


### PR DESCRIPTION
The timeout after connection creation works now as expected.
The timeout during connection creation is probably too long:
    `max_tries * (timeout + wait_tries)`