### PR TITLE
Allow to override sitemap time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - 2.7
 
 install:
-    - pip install -r requirements_dev.txt --use-mirrors 
+    - pip install -r requirements_dev.txt
     - python setup.py install
 
 script: python setup.py test

--- a/doc/sitemap_gen.py
+++ b/doc/sitemap_gen.py
@@ -2020,6 +2020,9 @@ def OpenFileForRead(path, logtext):
 
 def TimestampISO8601(t):
   """Seconds since epoch (1970-01-01) --> ISO 8601 time string."""
+  sde = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+  if t > sde:
+    t = sde
   return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(t))
 #end def TimestampISO8601
 

--- a/tests/004-test-client.py
+++ b/tests/004-test-client.py
@@ -112,7 +112,7 @@ def test_006(u, c):
     t.eq(r.body_string(), "ok")
     
 
-@t.client_request('http://e-engura.com/images/logo.gif')
+@t.client_request('http://www.lsmod.de/~bernhard/mirror/e-engura.com/images/logo.gif')
 def test_007(u, c):
     r = c.request(u)
     print r.status
@@ -124,7 +124,7 @@ def test_007(u, c):
     t.eq(imghdr.what(fname), 'gif')
     
 
-@t.client_request('http://e-engura.com/images/logo.gif')
+@t.client_request('http://www.lsmod.de/~bernhard/mirror/e-engura.com/images/logo.gif')
 def test_008(u, c):
     r = c.request(u)
     t.eq(r.status_int, 200)


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

When building the python-restkit openSUSE package,
some files are updated during the build
so mtime values always varied.